### PR TITLE
Standardize image sizes across modules

### DIFF
--- a/workspace/smart-courts-react/src/pages/ComputerVision.jsx
+++ b/workspace/smart-courts-react/src/pages/ComputerVision.jsx
@@ -83,7 +83,7 @@ function ComputerVision() {
           <motion.img
             src="/3d-court-illustration.png"
             alt="How it works diagram"
-            className="rounded-lg shadow-lg"
+            className="rounded-lg shadow-lg w-full h-72 md:h-96 object-contain"
             initial={{ opacity: 0, x: 50 }}
             whileInView={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.6 }}
@@ -95,7 +95,7 @@ function ComputerVision() {
           <motion.img
             src="/game-changer.png"
             alt="3D AI referee concept"
-            className="rounded-lg shadow-lg order-2 md:order-1"
+            className="rounded-lg shadow-lg order-2 md:order-1 w-full h-72 md:h-96 object-contain"
             initial={{ opacity: 0, x: -50 }}
             whileInView={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.6 }}
@@ -145,7 +145,7 @@ function ComputerVision() {
           <motion.img
             src="/industry-expansion-2D.png"
             alt="Cross-industry use cases"
-            className="rounded-lg shadow-lg"
+            className="rounded-lg shadow-lg w-full h-72 md:h-96 object-contain"
             initial={{ opacity: 0, x: 50 }}
             whileInView={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.6 }}

--- a/workspace/smart-courts-react/src/pages/MatchOrchestration.jsx
+++ b/workspace/smart-courts-react/src/pages/MatchOrchestration.jsx
@@ -81,7 +81,7 @@ function MatchOrchestration() {
           <motion.img
             src="/match-orchestration-how.png"
             alt="Match orchestration workflow"
-            className="rounded-lg shadow-lg"
+            className="rounded-lg shadow-lg w-full h-72 md:h-96 object-contain"
             initial={{ opacity: 0, x: 50 }}
             whileInView={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.6 }}
@@ -93,7 +93,7 @@ function MatchOrchestration() {
           <motion.img
             src="/match-orchestration-benefits.png"
             alt="Automated match orchestration benefits"
-            className="rounded-lg shadow-lg order-2 md:order-1"
+            className="rounded-lg shadow-lg order-2 md:order-1 w-full h-72 md:h-96 object-contain"
             initial={{ opacity: 0, x: -50 }}
             whileInView={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.6 }}

--- a/workspace/smart-courts-react/src/pages/PlayerAnalytics.jsx
+++ b/workspace/smart-courts-react/src/pages/PlayerAnalytics.jsx
@@ -75,7 +75,7 @@ function PlayerAnalytics() {
           <motion.img
             src="/player-analytics.png"
             alt="Player analytics process diagram"
-            className="rounded-lg shadow-lg"
+            className="rounded-lg shadow-lg w-full h-72 md:h-96 object-contain"
             initial={{ opacity: 0, x: 50 }}
             whileInView={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.6 }}
@@ -87,7 +87,7 @@ function PlayerAnalytics() {
           <motion.img
             src="/player-analytics-benefits.png"
             alt="Player analytics benefits illustration"
-            className="rounded-lg shadow-lg order-2 md:order-1"
+            className="rounded-lg shadow-lg order-2 md:order-1 w-full h-72 md:h-96 object-contain"
             initial={{ opacity: 0, x: -50 }}
             whileInView={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.6 }}


### PR DESCRIPTION
Standardize image sizes across PlayerAnalytics, ComputerVision, and MatchOrchestration pages for visual consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-049869d5-44b6-4e5e-adb3-e0f7f3ab6f5b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-049869d5-44b6-4e5e-adb3-e0f7f3ab6f5b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

